### PR TITLE
Added the extension .exe to the file proto-go-course

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-BIN = proto-go-course
 PROTO_DIR = proto
 
 ifeq ($(OS), Windows_NT)
@@ -6,6 +5,7 @@ ifeq ($(OS), Windows_NT)
 	SHELL := powershell.exe
 	.SHELLFLAGS := -NoProfile -Command
 	PACKAGE = $(shell Get-Content go.mod -head 1 | Foreach-Object { $$data = $$_ -split " "; "{0}" -f $$data[1]})
+	BIN = proto-go-course.exe
 else
 	UNAME := $(shell uname -s)
 	ifeq ($(UNAME),Darwin)
@@ -16,6 +16,7 @@ else
     	$(error OS not supported by this Makefile)
 	endif
 	PACKAGE = $(shell head -1 go.mod | awk '{print $$2}')
+	BIN = proto-go-course
 endif
 
 build: 	generate


### PR DESCRIPTION
The run the output file in windows os, the .exe extension is required.